### PR TITLE
feat: add shortcuts to switch between editors

### DIFF
--- a/main.js
+++ b/main.js
@@ -116,3 +116,23 @@ function createHtml ({ html, js, css }) {
 </html>
   `
 }
+
+const currentLayout = {
+  html: {
+    ArrowRight: jsEditor,
+    ArrowDown: cssEditor
+  },
+  css: {
+    ArrowUp: htmlEditor,
+    ArrowRight: jsEditor
+  },
+  js: {
+    ArrowLeft: htmlEditor,
+    ArrowDown: cssEditor
+  }
+}
+
+htmlEditor.focus()
+htmlEditor.onKeyDown((event) => event.altKey && event.ctrlKey && currentLayout.html[event.code]?.focus())
+jsEditor.onKeyDown((event) => event.altKey && event.ctrlKey && currentLayout.js[event.code]?.focus())
+cssEditor.onKeyDown((event) => event.altKey && event.ctrlKey && currentLayout.css[event.code]?.focus())


### PR DESCRIPTION
Closes #15 

The idea behind this PR is to add some comfort when the user want to switch between editors (HTML, JS and CSS). Right now the logic is adapted to the current layout, if finally the application had more layouts, the behavior would have to be modified according to the current layout.

The shortcut to navigate between editors is: `control` + `alt` + some arrow key 😉

Also, I set the default focus in the HTML editor.