### PR TITLE
Fixed monaco widget overflow

### DIFF
--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ const js = rawJs ? decode(rawJs) : ''
 const COMMON_EDITOR_OPTIONS = {
   automaticLayout: true,
   fontSize: 18,
+  fixedOverflowWidgets: true,
   scrollBeyondLastLine: false,
   roundedSelection: false,
   padding: {


### PR DESCRIPTION
Issue #28
Added a line in monaco editor settings. This allows the widgets belonging to each editor to be positioned with a fixed and in case of overflowing they overlap on other editors and elements

![before-after-HTML](https://user-images.githubusercontent.com/15878526/131787963-ff8c4b2e-8163-403a-aeae-54d29eeb2905.png)

![before-after-CSS](https://user-images.githubusercontent.com/15878526/131788948-8e9ec6f8-25f0-4cb5-9773-b6fc71adad13.png)
