### PR TITLE
fix(Root): name error when importing if package has user scope

### DIFF
--- a/src/skypack.js
+++ b/src/skypack.js
@@ -56,5 +56,7 @@ async function fetchPackages (packageName) {
 }
 
 function handlePackageSelected (packageName) {
-  window.postMessage({ package: packageName, url: `${CDN_URL}/${packageName}` })
+  let parsedName = packageName.split('/').join('-')
+  if (parsedName.startsWith('@')) parsedName = parsedName.substr(1)
+  window.postMessage({ package: parsedName, url: `${CDN_URL}/${packageName}` })
 }


### PR DESCRIPTION
Fixed bug when importing packages with the following name **@owner/package-name**