### PR TITLE
Add support to download the user code via zip button

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
               <span role="tooltip" class="button-title">Skypack</span>
               <svg fill="#C5C5C5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 26"><path d="M17.387 12.213L10.95 9l6.438-3.212c.3-.15.487-.45.487-.788a.875.875 0 00-.488-.788l-8-4a.874.874 0 00-.787 0l-8 4c-.3.15-.487.45-.487.788v8c0 .3.162.588.412.75l.075.037L7.038 17 .6 20.212c-.3.15-.487.45-.487.788 0 .337.187.637.487.788l8 4a.874.874 0 00.388.087.874.874 0 00.387-.087l8-4c.3-.15.488-.45.488-.788v-8a.842.842 0 00-.476-.787zM9 1.975L15.037 5 9 8.025 2.963 5 9 1.975zM1.875 6.413L7.038 9l-5.163 2.588V6.413zM2.963 13L9 9.975 15.037 13 9 16.025 2.963 13zm5.162 5.413v5.162l-5.162-2.587 5.162-2.575zm8 2.05l-6.25 3.124V17.55l6.25-3.125v6.037z"></path></svg>
             </button>
+
+            <button data-action="download-user-code" data-is-simple-click-action="true">
+              <span role="tooltip" class="button-title">Download</span>
+              <svg width="24" height="24" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 1h11v6l-1 1v7H2V2l1-1Zm3 1H5v2h1V2Zm0 12h4V8L9 7V2H7v3H6v1H5V5H4V2H3v12h2v-1h1v1Zm0-2v1h1v-1H6Zm0-1v1H5v-1h1Zm0-1h1v1H6v-1Zm0-1v1H5V9h1Zm0-1h1v1H6V8Zm0-1v1H5V7h1Zm0 0h1V6H6v1Zm6 0 1-1V2h-3v4l1 1v7h1V7Z" fill="#C5C5C5"/></svg>
+            </button>
           </header>
   
           <footer>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eventemitter3": "4.0.7",
     "hotkeys-js": "3.8.7",
     "js-base64": "3.6.1",
+    "jszip": "3.7.1",
     "monaco-editor": "0.27.0",
     "split-grid": "1.0.11",
     "zustand": "3.5.10"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "emmet-monaco-es": "^4.7.1",
+    "eventemitter3": "4.0.7",
     "hotkeys-js": "3.8.7",
     "js-base64": "3.6.1",
     "monaco-editor": "0.27.0",

--- a/src/aside.js
+++ b/src/aside.js
@@ -1,34 +1,53 @@
+import { EE, EVENTS } from './events-controller.js'
 import { $, $$ } from './utils/dom.js'
 
 const $aside = $('aside')
 const $buttons = $$('button', $aside)
 
-const ACTIONS = {
+const SIMPLE_CLICK_ACTIONS = {
+  'download-user-code': () => {
+    EE.emit(EVENTS.DOWNLOAD_USER_CODE)
+  }
+}
+
+const NON_SIMPLE_CLICK_ACTIONS = {
   'close-aside-bar': () => {
     $('.aside-bar').setAttribute('hidden', '')
   },
 
   'show-skypack-bar': () => {
-    $('.aside-bar').removeAttribute('hidden')
-    $$('.bar-content').forEach(el => el.setAttribute('hidden', ''))
-    $('#skypack').removeAttribute('hidden')
+    showAsideBar('#skypack')
   },
 
   'show-settings-bar': () => {
-    $('.aside-bar').removeAttribute('hidden')
-    $$('.bar-content').forEach(el => el.setAttribute('hidden', ''))
-    $('#settings').removeAttribute('hidden')
+    showAsideBar('#settings')
   }
+}
+
+const showAsideBar = (selector) => {
+  $('.aside-bar').removeAttribute('hidden')
+  $$('.bar-content').forEach(el => el.setAttribute('hidden', ''))
+  $(selector).removeAttribute('hidden')
+}
+
+const ACTIONS = {
+  ...SIMPLE_CLICK_ACTIONS,
+  ...NON_SIMPLE_CLICK_ACTIONS
 }
 
 $buttons.forEach(button => {
   button.addEventListener('click', ({ currentTarget }) => {
+    let action = button.getAttribute('data-action')
+    const isSimpleClickAction = button.getAttribute('data-is-simple-click-action') === 'true'
+
+    if (isSimpleClickAction) return ACTIONS[action]()
+
     const alreadyActive = currentTarget.classList.contains('is-active')
     $('.is-active').classList.remove('is-active')
 
-    const action = alreadyActive
+    action = alreadyActive
       ? 'close-aside-bar'
-      : button.getAttribute('data-action')
+      : action
 
     const elementToActive = alreadyActive
       ? $("button[data-action='close-aside-bar']")

--- a/src/download.js
+++ b/src/download.js
@@ -1,0 +1,71 @@
+import JSZip from 'jszip'
+
+export function downloadUserCode ({
+  htmlContent,
+  cssContent,
+  jsContent,
+  fileName = 'codi.link',
+  zipInSingleFile = false
+}) {
+  const createZip = zipInSingleFile ? createZipWithSingleFile : createZipWithMultipleFiles
+
+  const zip = createZip({ htmlContent, cssContent, jsContent })
+  generateZip({ zip, fileName })
+}
+
+function createZipWithSingleFile ({ htmlContent, cssContent, jsContent }) {
+  const zip = new JSZip()
+
+  const indexHtml = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      ${cssContent}
+    </style>
+  </head>
+  <body>
+    ${htmlContent}
+    <script type="module">
+    ${jsContent}
+    </script>
+  </body>
+</html>`
+
+  zip.file('index.html', indexHtml)
+
+  return zip
+}
+
+function createZipWithMultipleFiles ({ htmlContent, cssContent, jsContent }) {
+  const zip = new JSZip()
+
+  const indexHtml = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link type="text/css" rel="stylesheet" href="css/style.css"/>
+  </head>
+  <body>
+    ${htmlContent}
+    <script type="module" src="js/script.js"></script>
+  </body>
+</html>`
+
+  zip.file('css/style.css', cssContent)
+  zip.file('js/script.js', jsContent)
+  zip.file('index.html', indexHtml)
+
+  return zip
+}
+
+function generateZip ({ zip, fileName }) {
+  zip.generateAsync({ type: 'blob' }).then((blobData) => {
+    const zipBlob = new window.Blob([blobData])
+    const element = window.document.createElement('a')
+
+    element.href = window.URL.createObjectURL(zipBlob)
+    element.download = `${fileName}.zip`
+    element.click()
+  })
+}

--- a/src/events-controller.js
+++ b/src/events-controller.js
@@ -1,0 +1,36 @@
+import { EventEmitter } from 'eventemitter3'
+import { capitalize } from './utils/string.js'
+import { downloadUserCode } from './download.js'
+
+export const EE = new EventEmitter()
+
+let jsEditor
+let htmlEditor
+let cssEditor
+
+export const initializeEventsController = ({
+  jsEditor: _jsEditor,
+  htmlEditor: _htmlEditor,
+  cssEditor: _cssEditor
+}) => {
+  jsEditor = _jsEditor
+  htmlEditor = _htmlEditor
+  cssEditor = _cssEditor
+}
+
+export const EVENTS = {
+  ADD_SKYPACK_PACKAGE: 'ADD_SKYPACK_PACKAGE',
+  DOWNLOAD_USER_CODE: 'DOWNLOAD_USER_CODE'
+}
+
+EE.on(EVENTS.ADD_SKYPACK_PACKAGE, ({ skypackPackage, url }) => {
+  jsEditor.setValue(`import ${capitalize(skypackPackage)} from '${url}';\n${jsEditor.getValue()}`)
+})
+
+EE.on(EVENTS.DOWNLOAD_USER_CODE, () => {
+  downloadUserCode({
+    htmlContent: htmlEditor.getValue(),
+    cssContent: cssEditor.getValue(),
+    jsContent: jsEditor.getValue()
+  })
+})

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,8 @@ import { encode, decode } from 'js-base64'
 import { $ } from './utils/dom.js'
 import { createEditor } from './editor.js'
 import debounce from './utils/debounce.js'
-import { capitalize } from './utils/string'
 import { subscribe } from './state'
+import { initializeEventsController } from './events-controller.js'
 
 import './aside.js'
 import './skypack.js'
@@ -28,12 +28,6 @@ const js = rawJs ? decode(rawJs) : ''
 const htmlEditor = createEditor({ domElement: $html, language: 'html', value: html })
 const cssEditor = createEditor({ domElement: $css, language: 'css', value: css })
 const jsEditor = createEditor({ domElement: $js, language: 'javascript', value: js })
-
-window.onmessage = ({ data }) => {
-  if (Object.prototype.toString.call(data) === '[object Object]' && Object.keys(data).includes('package')) {
-    jsEditor.setValue(`import ${capitalize(data.package)} from '${data.url}';\n${jsEditor.getValue()}`)
-  }
-}
 
 subscribe(state => {
   const EDITORS = [htmlEditor, cssEditor, jsEditor]
@@ -63,6 +57,7 @@ cssEditor.onDidChangeModelContent(debouncedUpdate)
 jsEditor.onDidChangeModelContent(debouncedUpdate)
 
 initEditorHotKeys({ htmlEditor, cssEditor, jsEditor })
+initializeEventsController({ htmlEditor, cssEditor, jsEditor })
 
 const htmlForPreview = createHtml({ html, js, css })
 $('iframe').setAttribute('srcdoc', htmlForPreview)

--- a/src/skypack.js
+++ b/src/skypack.js
@@ -1,3 +1,4 @@
+import { EE, EVENTS } from './events-controller.js'
 import debounce from './utils/debounce.js'
 import { $ } from './utils/dom.js'
 
@@ -58,5 +59,6 @@ async function fetchPackages (packageName) {
 function handlePackageSelected (packageName) {
   let parsedName = packageName.split('/').join('-')
   if (parsedName.startsWith('@')) parsedName = parsedName.substr(1)
-  window.postMessage({ package: parsedName, url: `${CDN_URL}/${packageName}` })
+
+  EE.emit(EVENTS.ADD_SKYPACK_PACKAGE, { skypackPackage: parsedName, url: `${CDN_URL}/${packageName}` })
 }


### PR DESCRIPTION
- Add an event emitter, because we need to communicate in a better way than window.postMessage, so the skypack part was refactorized before implement the download button feature. 
- Add a download button in the aside bar. This button don't open a panel, so we need to do some refactor in the aside.js file.
- Add a download functionality with this default settings: ```zipInSingleFile=false``` and ```fileName=codi.link```
- All download config options has been tested, but there are not exposed to the app yet (maybe in next iterations?)
- Use the vscode official icon (optimized via svg omg ;) ): https://github.com/microsoft/vscode-icons/blob/main/icons/dark/file-zip.svg

ISSUES CLOSED: #19 