### PR TITLE
fix(Root): Fix correct flow in fields elements in aside of settings panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                   Font Size
                 </strong>
                 Controls the font size in pixels.
-                <input data-for="fontSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" tabindex="-1" value="16">
+                <input data-for="fontSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" value="16">
               </div>
 
               <div class="settings-item">

--- a/src/style.css
+++ b/src/style.css
@@ -350,12 +350,21 @@ select {
   }
 
   & .checkbox input {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
   }
 
   & .checkbox span {
     display: flex;
     align-items: center;
+  }
+
+  & .checkbox input:focus + span::before {
+    content: '';
+    outline: 1px solid #fff;
   }
 
   & .checkbox input:checked + span::before {


### PR DESCRIPTION
## Accesible flow focus in fields elements
- [x] Remove tabindex -1 to input number of font size
- [x]  Add focus state to chekcbox elements

![image](https://user-images.githubusercontent.com/32694631/135702018-71301bb6-9971-43f6-9f38-2188bac82a79.png)
