### PR TITLE
fix(Root): Fix console worker warnings

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1,5 +1,6 @@
 import * as monaco from 'monaco-editor'
 import { emmetHTML } from 'emmet-monaco-es'
+import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker'
 import HtmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import CssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker'
 import JsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
@@ -42,6 +43,7 @@ window.MonacoEnvironment = {
     if (label === 'html') return new HtmlWorker()
     if (label === 'javascript') return new JsWorker()
     if (label === 'css') return new CssWorker()
+    return new EditorWorker()
   }
 }
 


### PR DESCRIPTION
Default worker now points to editor worker

![Fix console warning](https://user-images.githubusercontent.com/45363951/135720833-4c39b9ca-78bc-41ea-a9bc-ef0350455b49.png)


