### PR TITLE
fix(Root): autocomplete html tag bugs

### DIFF
--- a/src/editor-extensions/autocomplete-html-tag.js
+++ b/src/editor-extensions/autocomplete-html-tag.js
@@ -33,7 +33,7 @@ const getMatchingTagName = ({ model, position: { lineNumber, column } }) => {
     endColumn: column
   })
 
-  return textFromCurrentLineUntilPosition.match(/.*<(\w+)>$/)?.[1]
+  return textFromCurrentLineUntilPosition.match(/.*<(\w+).*>$/)?.[1]
 }
 
 const checkIsEmptyTag = (tagName) => EMPTY_HTML_TAGS.includes(tagName)


### PR DESCRIPTION
## Description <!-- [mandatory] -->
The goal of this PR is to fix a couple of bugs mentioned in [this twitch live ](https://www.twitch.tv/videos/1170119221).

<!-- Links to stories go here. -->

## List of changes <!-- [mandatory] -->

<!--
* This changed
* That changed
* etc.
* -->
* fix: hide autocomplete for empty tags
* fix: show autocomplete for tags with attributes

## Steps to Test or Reproduce <!-- [mandatory] -->

* try to add attributes to html tags, like `<p class="foo">`,  it should suggest the autocomplete for the tag
* try to close (`>`) html tags that are [empty elements](https://developer.mozilla.org/en-US/docs/Glossary/Empty_element), like `<input />`, `<area />`, etc, it shouldn't suggest the autocomplete for these kind of tags.

<!--  Outline the steps to test or reproduce the PR here.

* Go to module X
* click on Y
* check that Z is visible in the screen.
-->

<!--
## Screenshots
### Before
### After
-->
## Screenshots
### Before
![Screenshot from 2021-10-08 00-44-12](https://user-images.githubusercontent.com/6330366/136496305-bc4c8519-1802-4add-b08c-67cd9c44a690.png)
### After
![Screenshot from 2021-10-08 00-44-23](https://user-images.githubusercontent.com/6330366/136496320-50a8d5c7-75a9-4b16-8c95-62774751dc36.png)

### Before
![Screenshot from 2021-10-08 00-43-26](https://user-images.githubusercontent.com/6330366/136496338-460829f4-4806-4e4a-b776-ebb58d9cdda8.png)

### After
![Screenshot from 2021-10-08 00-43-43](https://user-images.githubusercontent.com/6330366/136496347-84a2c7ec-9214-4402-84ea-27a75a36ac1c.png)

Note: this is just in case the user doesn't close an empty tag in a proper way.

## Impacted Areas in Application <!-- [mandatory] -->
HTML Editor
<!--  List general components of the application that this PR will affect. -->

<!--
## Requires dependency installation
YES | NO
-->

<!--
## Migrations
YES | NO
-->

<!--
## Related PRs
List related PRs against other branches

branch | PR [mandatory]
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
-->

<!--
## Todos
- [ ] Tests
- [ ] Documentation
-->

<!--
## Deploy Notes
Notes regarding deployment the contained body of work.
-->

<!--
## WIP
If it's a work in progress task, add a short description for the reasons of that state.
-->

