### PR TITLE
Add jsx support

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,15 @@
                 </div>
               </div>
 
+              <div class="settings-item">
+                <strong>
+                  <span class="settings-type">Features › JSX:</span>
+                </strong>
+                <label class="checkbox">
+                  <input data-for="jsxEnabled" type="checkbox" />
+                  <span>Enable JSX</span>
+                </label>
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -207,12 +207,20 @@
 
               <div class="settings-item">
                 <strong>
-                  <span class="settings-type">Features › JSX:</span>
+                  <span class="settings-type">Features › JSX</span>
                 </strong>
                 <label class="checkbox">
                   <input data-for="jsxEnabled" type="checkbox" />
                   <span>Enable JSX</span>
                 </label>
+                <div>
+                  <strong>JSX custom function:</strong>
+                  <input class="input" data-for="jsxPragma" type="text" />
+                </div>
+                <div>
+                  <strong>JSX custom fragment:</strong>
+                  <input class="input" data-for="jsxPragmaFrag" type="text" />
+                </div>
               </div>
             </div>
           </div>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "cypress": "8.5.0"
   },
   "dependencies": {
-    "emmet-monaco-es": "4.7.2",
+    "@babel/core": "^7.15.8",
+    "@babel/preset-react": "^7.14.5",
+    "@babel/standalone": "^7.15.8",
+    "emmet-monaco-es": "^4.7.2",
     "escape-html": "1.0.3",
     "hotkeys-js": "3.8.7",
     "js-base64": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@babel/core": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
     "@babel/standalone": "^7.15.8",
-    "emmet-monaco-es": "^4.7.2",
+    "emmet-monaco-es": "4.7.2",
     "escape-html": "1.0.3",
     "hotkeys-js": "3.8.7",
     "js-base64": "3.7.2",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "devDependencies": {
     "@s-ui/mono": "2",
+    "cypress": "8.5.0",
     "postcss-nesting": "8.0.1",
     "standard": "16.0.4",
-    "vite": "2.6.3",
-    "cypress": "8.5.0"
+    "vite": "2.6.3"
   },
   "dependencies": {
     "@babel/core": "^7.15.8",

--- a/src/constants/initial-settings.js
+++ b/src/constants/initial-settings.js
@@ -16,5 +16,6 @@ export const DEFAULT_INITIAL_SETTINGS = {
     gutters: DEFAULT_LAYOUT,
     style: DEFAULT_GRID_TEMPLATE,
     type: 'default'
-  }
+  },
+  jsxEnabled: true
 }

--- a/src/constants/initial-settings.js
+++ b/src/constants/initial-settings.js
@@ -17,5 +17,7 @@ export const DEFAULT_INITIAL_SETTINGS = {
     style: DEFAULT_GRID_TEMPLATE,
     type: 'default'
   },
-  jsxEnabled: true
+  jsxEnabled: true,
+  jsxPragma: 'React.createElement',
+  jsxPragmaFrag: 'React.Fragment'
 }

--- a/src/jsx-support.js
+++ b/src/jsx-support.js
@@ -1,12 +1,17 @@
 import { transform } from '@babel/standalone'
-import pluginReact from '@babel/preset-react'
+import presetReact from '@babel/preset-react'
+import { getState } from './state.js'
 
 export default function (code) {
+  const { jsxEnabled } = getState()
+
+  if (!jsxEnabled) return code
+
   return transform(code, {
     babelrc: false,
     configFile: false,
     ast: false,
-    highlightCode: true,
-    presets: [pluginReact]
+    highlightCode: false,
+    presets: [presetReact]
   }).code
 }

--- a/src/jsx-support.js
+++ b/src/jsx-support.js
@@ -1,0 +1,12 @@
+import { transform } from '@babel/standalone'
+import pluginReact from '@babel/preset-react'
+
+export default function (code) {
+  return transform(code, {
+    babelrc: false,
+    configFile: false,
+    ast: false,
+    highlightCode: true,
+    presets: [pluginReact]
+  }).code
+}

--- a/src/jsx-support.js
+++ b/src/jsx-support.js
@@ -3,7 +3,7 @@ import presetReact from '@babel/preset-react'
 import { getState } from './state.js'
 
 export default function (code) {
-  const { jsxEnabled } = getState()
+  const { jsxEnabled, jsxPragma, jsxPragmaFrag } = getState()
 
   if (!jsxEnabled) return code
 
@@ -12,6 +12,14 @@ export default function (code) {
     configFile: false,
     ast: false,
     highlightCode: false,
-    presets: [presetReact]
+    presets: [
+      [
+        presetReact,
+        {
+          pragma: jsxPragma,
+          pragmaFrag: jsxPragmaFrag
+        }
+      ]
+    ]
   }).code
 }

--- a/src/main.js
+++ b/src/main.js
@@ -76,9 +76,9 @@ $('iframe').setAttribute('srcdoc', initialHtmlForPreview)
 function update () {
   const html = htmlEditor.getValue()
   const css = cssEditor.getValue()
-  const js = jsxCompiler(jsEditor.getValue())
+  const js = jsEditor.getValue()
 
-  const htmlForPreview = createHtml({ html, js, css })
+  const htmlForPreview = createHtml({ html, js: jsxCompiler(js), css })
   $('iframe').setAttribute('srcdoc', htmlForPreview)
 
   WindowPreviewer.updateWindowContent(htmlForPreview)

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import { initializeEventsController } from './events-controller.js'
 import { getState, subscribe } from './state.js'
 import WindowPreviewer from './utils/WindowPreviewer.js'
 import setGridLayout from './grid.js'
+import jsxCompiler from './jsx-support.js'
 
 import './aside.js'
 import './skypack.js'
@@ -75,7 +76,7 @@ $('iframe').setAttribute('srcdoc', initialHtmlForPreview)
 function update () {
   const html = htmlEditor.getValue()
   const css = cssEditor.getValue()
-  const js = jsEditor.getValue()
+  const js = jsxCompiler(jsEditor.getValue())
 
   const htmlForPreview = createHtml({ html, js, css })
   $('iframe').setAttribute('srcdoc', htmlForPreview)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  define: {
+    'process.env.BABEL_TYPES_8_BREAKING': false
+  }
+})


### PR DESCRIPTION
This add jsx support with babel. Fixes #68.

## Continued development
- [x] Add option to disable jsx
- [x] Add option to use custom function instead `React.createElement`

### Extras
Add syntax colors to editor (I can't 😅)