### PR TITLE
fix: problem loading previous project on Firefox

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ const $html = $('#html')
 
 const { pathname } = window.location
 
-const [rawHtml, rawCss, rawJs] = pathname.slice(1).split('%7C')
+const [rawHtml, rawCss, rawJs] = pathname.slice(1).split(/%7C|\|/)
 
 const html = rawHtml ? decode(rawHtml) : ''
 const css = rawCss ? decode(rawCss) : ''


### PR DESCRIPTION
- [x] Fix : #111

Some chars aren't escape on URL for Firefox and cause problem on read hashed code for previous project. 
This fix that.