### PR TITLE
Add listener and tabindex to navigate and select skypack libraries

### DIFF
--- a/src/skypack.js
+++ b/src/skypack.js
@@ -116,10 +116,14 @@ function displayResults ({ results, searchTerm }) {
     const $li = document.createElement('li')
     $li.title = result.description
     $li.innerHTML = getResultHTML({ result, searchTerm })
+    $li.tabIndex = 0
 
     $li.addEventListener('click', (e) => {
       if (e.target.className === 'skypack-open') return
       handlePackageSelected(result.name)
+    })
+    $li.addEventListener('keydown', (e) => {
+      if (e.keyCode === 13) handlePackageSelected(result.name)
     })
 
     $searchResultsList.appendChild($li)
@@ -137,7 +141,7 @@ function getResultHTML ({ result, searchTerm }) {
     <section class="skypack-description">${escapeHTML(result.description)}</section>
     <footer>
       <div class="skypack-updated" >Updated: ${updatedAt}</div>
-      <a class="skypack-open" target="_blank" href="${PACKAGE_VIEW_URL}/${result.name}">details</a>
+      <a tabindex="-1" class="skypack-open" target="_blank" href="${PACKAGE_VIEW_URL}/${result.name}">details</a>
     </footer>`
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -649,6 +649,7 @@ select {
     }
   }
 
+  & .search-results ul li:focus,
   & .search-results ul li:hover {
     background-color: rgba(128, 128, 128, 0.14);
 


### PR DESCRIPTION
Hello midu.
A pleasure to collaborate with this community.
Thank you very much for the work you do.

I want to contribute with this small feature, which may be interesting.

On search for Skypack when list is rendered, we can navigate with tab key (next), shift+tab (prev) and enter (select).

Image
![image](https://user-images.githubusercontent.com/6350474/138502362-e00754e7-7191-443c-8436-768fa14c4dee.png)
