### PR TITLE
Add alternative command for trigger suggestions

### DIFF
--- a/src/components/codi-editor/extensions/editor-hotkeys.js
+++ b/src/components/codi-editor/extensions/editor-hotkeys.js
@@ -22,4 +22,9 @@ export const initEditorHotKeys = (editor) => {
       copyToClipboard(window.location.href)
     }
   )
+  editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Space,
+    function () {
+      editor.trigger('', 'editor.action.triggerSuggest', {})
+    }
+  )
 }


### PR DESCRIPTION
Hi Midu,

What do you think of this idea?

I think it is a good idea to have an alternative command for triggerSuggestios because of the fact that "CtrlCmd + Space" is a popular command for example to open Spotlight and other applications.

I have added the shortcut "Shift + Space" and it works together with "CtrlCmd + Space".

In my local VSCode I have this shortcut.

Thanks