### PR TITLE
Feat: add option to change sidebar size

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,20 @@
 
               <div class="settings-item">
                 <strong>
+                  <span class="settings-type">Workbench:</span>
+                  Sidebar Style
+                </strong>
+                Specifies the size of the Sidebar.
+                <div class="select">
+                  <select data-for="sidebar">
+                    <option value="default">Default</option>
+                    <option value="compact">Compact</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="settings-item">
+                <strong>
                   <span class="settings-type">Editor:</span>
                   Font Size
                 </strong>

--- a/src/constants/initial-settings.js
+++ b/src/constants/initial-settings.js
@@ -10,6 +10,7 @@ export const DEFAULT_INITIAL_SETTINGS = {
   minimap: false,
   preserveGrid: true,
   theme: 'vs-dark',
+  sidebar: 'default',
   wordWrap: 'on',
   zipFileName: 'codi.link',
   zipInSingleFile: false,

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { initializeEventsController } from './events-controller.js'
 import { getState, subscribe } from './state.js'
 import WindowPreviewer from './utils/WindowPreviewer.js'
 import setGridLayout from './grid.js'
+import setSidebar from './sidebar.js'
 import { configurePrettierHotkeys } from './monaco-prettier/configurePrettier'
 
 import './aside.js'
@@ -20,9 +21,10 @@ import { BUTTON_ACTIONS } from './constants/button-actions.js'
 import './components/layout-preview/layout-preview.js'
 import './components/codi-editor/codi-editor.js'
 
-const { layout: currentLayout } = getState()
+const { layout: currentLayout, sidebar } = getState()
 
 setGridLayout(currentLayout)
+setSidebar(sidebar)
 
 const editorElements = $$('codi-editor')
 
@@ -60,6 +62,7 @@ subscribe(state => {
     })
   })
   setGridLayout(state.layout)
+  setSidebar(state.sidebar)
 })
 
 const MS_UPDATE_DEBOUNCED_TIME = 200

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -1,0 +1,15 @@
+import { $ } from './utils/dom.js'
+
+const setSideBar = (sideBarStyle) => {
+  const sideBar = $('.aside-sections')
+
+  if (sideBarStyle === 'compact') {
+    sideBar.classList.add('aside-sections--compact')
+  }
+
+  if (sideBarStyle === 'default') {
+    sideBar.classList.remove('aside-sections--compact')
+  }
+}
+
+export default setSideBar

--- a/src/style.css
+++ b/src/style.css
@@ -340,6 +340,15 @@ aside button.is-active {
   justify-content: center;
 }
 
+.aside-sections--compact {
+  width: 52px;
+}
+
+.aside-sections--compact svg {
+  width: 25px;
+  height: 25px;
+}
+
 [hidden] {
   display: none !important;
 }


### PR DESCRIPTION
I think that the sidebar and its icons are very large, so I have added the option to make it compact to have more space available in the editor.

Apart from "compact", it allows the possibility of adding new options in the future by other users, such as "hidden" to hide the sidebar (or make a much thinner bar without icons) and only show it when placing the cursor on the left side of the screen or clicking in it (just a idea).

This is my first contribution to a public project and I'm not sure if I did it the right way, so anyone can feel free to suggest any changes.

![compact sidebar](https://user-images.githubusercontent.com/75083623/141786482-34558fec-3206-48ff-a436-bdc441be9e54.PNG)