### PR TITLE
Support editing CSS without reloading preview

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,8 @@ const { layout: currentLayout } = getState()
 
 setGridLayout(currentLayout)
 
+const iframe = $('iframe')
+
 const editorElements = $$('codi-editor')
 
 const { pathname } = window.location
@@ -71,17 +73,19 @@ const { html: htmlEditor, css: cssEditor, javascript: jsEditor } = EDITORS
 const { html, css, javascript: js } = VALUES
 
 htmlEditor.focus()
-Object.values(EDITORS).forEach(editor => editor.onDidChangeModelContent(debouncedUpdate))
+Object.values(EDITORS).forEach(editor => {
+  editor.onDidChangeModelContent(() => debouncedUpdate({ notReload: editor === cssEditor }))
+})
 initializeEventsController({ htmlEditor, cssEditor, jsEditor })
 
 const initialHtmlForPreview = createHtml({ html, js, css })
-$('iframe').setAttribute('srcdoc', initialHtmlForPreview)
+iframe.setAttribute('srcdoc', initialHtmlForPreview)
 configurePrettierHotkeys([htmlEditor, cssEditor, jsEditor])
 
 const initButtonAvailabilityIfContent = () => updateButtonAvailabilityIfContent({ html, js, css })
 initButtonAvailabilityIfContent()
 
-function update () {
+function update ({ notReload }) {
   const values = {
     html: htmlEditor.getValue(),
     css: cssEditor.getValue(),
@@ -89,11 +93,21 @@ function update () {
   }
 
   const htmlForPreview = createHtml(values)
-  $('iframe').setAttribute('srcdoc', htmlForPreview)
+
+  if (!notReload) {
+    iframe.setAttribute('srcdoc', htmlForPreview)
+  }
+
+  updateCss()
 
   WindowPreviewer.updateWindowContent(htmlForPreview)
   debouncedUpdateHash(values)
   updateButtonAvailabilityIfContent(values)
+}
+
+function updateCss () {
+  iframe.contentDocument
+    .querySelector('#preview-style').textContent = cssEditor.getValue()
 }
 
 function updateHashedCode ({ html, css, js }) {

--- a/src/utils/createHtml.js
+++ b/src/utils/createHtml.js
@@ -12,7 +12,7 @@ export const createHtml = ({ css, html, js }) => {
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <style>
+    <style id="preview-style">
       ${css}
     </style>
   </head>


### PR DESCRIPTION
This solves #185

With this change, anytime the user writes changes to the CSS, the content of the style tag is updated directly instead of changing the `srcdoc`. This way the iframe document doesn't reload and any Javascript state is retained.

The behavior retains the same when the user changes the JavaScript or the HTML.

This PR is open to reviews, opinions and suggestions for improvement. Please tell me if there is any edge case where this doesn't work.