### PR TITLE
Use native EventTarget instead of mitt

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "@s-ui/mono": "2",
+    "cypress": "8.6.0",
     "postcss-nesting": "8.0.1",
     "standard": "16.0.4",
-    "vite": "2.6.7",
-    "cypress": "8.6.0"
+    "vite": "2.6.7"
   },
   "dependencies": {
     "css-format-monaco": "2.0.4",
@@ -28,7 +28,6 @@
     "js-base64": "3.7.2",
     "jszip": "3.7.1",
     "lit": "2.0.2",
-    "mitt": "3.0.0",
     "monaco-editor": "0.29.1",
     "split-grid": "1.0.11",
     "zustand": "3.5.13"

--- a/src/events-controller.js
+++ b/src/events-controller.js
@@ -1,9 +1,24 @@
-import mitt from 'mitt'
 import { capitalize, searchByLine } from './utils/string.js'
 import { downloadUserCode } from './download.js'
 import { getState } from './state'
 
-export const eventBus = mitt()
+class EventBus extends window.EventTarget {
+  on (type, listener) {
+    this.addEventListener(type, listener)
+  }
+
+  off (type, listener) {
+    this.removeEventListener(type, listener)
+  }
+
+  emit (type, detail) {
+    const event = new window.CustomEvent(type, { detail, cancelable: true })
+
+    this.dispatchEvent(event)
+  }
+}
+
+export const eventBus = new EventBus()
 
 let jsEditor
 let htmlEditor
@@ -25,7 +40,7 @@ export const EVENTS = {
   DRAG_FILE: 'DRAG_FILE'
 }
 
-eventBus.on(EVENTS.ADD_SKYPACK_PACKAGE, ({ skypackPackage, url }) => {
+eventBus.on(EVENTS.ADD_SKYPACK_PACKAGE, ({ detail: { skypackPackage, url } }) => {
   const importStatement = `import ${capitalize(skypackPackage)} from '${url}';`
   const existPackage = searchByLine(jsEditor.getValue(), url)
   if (!existPackage) {
@@ -48,7 +63,7 @@ eventBus.on(EVENTS.DOWNLOAD_USER_CODE, () => {
   })
 })
 
-eventBus.on(EVENTS.DRAG_FILE, ({ content, typeFile }) => {
+eventBus.on(EVENTS.DRAG_FILE, ({ detail: { content, typeFile } }) => {
   const file = typeFile
 
   switch (file) {


### PR DESCRIPTION
Replace the eventBus inplementation to use the native EventTarget API
instead of a third party library.