### PR TITLE
Use an HTML form for settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
             </div>
           </div>
 
-          <div id="settings" hidden class="bar-content settings">
+          <form id="settings" hidden class="bar-content settings">
             <div class="settings-content">
               <div class="settings-item">
                 <strong>
@@ -96,7 +96,7 @@
                 </strong>
                 Controls the display of line numbers.
                 <div class="select">
-                  <select data-for="lineNumbers">
+                  <select name="lineNumbers">
                     <option value="on">on</option>
                     <option value="off">off</option>
                     <option value="relative">relative</option>
@@ -112,7 +112,7 @@
                 </strong>
                 Controls how lines should wrap.
                 <div class="select">
-                  <select data-for="wordWrap">
+                  <select name="wordWrap">
                     <option value="on">on</option>
                     <option value="off">off</option>
                     <option value="wordWrapColumn">wordWrapColumn</option>
@@ -128,7 +128,7 @@
                 </strong>
                 Specifies the color theme used in the workbench.
                 <div class="select">
-                  <select data-for="theme">
+                  <select name="theme">
                     <option value="vs-dark">Dark</option>
                     <option value="vs">Light</option>
                     <option value="hc-black">High Contrast Dark</option>
@@ -142,7 +142,7 @@
                   Font Size
                 </strong>
                 Controls the font size in pixels.
-                <input data-for="fontSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" value="16" min="1" max="100" step="1">
+                <input name="fontSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" value="16" min="1" max="100" step="1">
               </div>
 
               <div class="settings-item">
@@ -151,7 +151,7 @@
                   Tab Size
                 </strong>
                 Controls the tab size.
-                <input data-for="tabSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" value="2" min="1" max="100" step="1">
+                <input name="tabSize" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" wrap="off" value="2" min="1" max="100" step="1">
               </div>
 
               <div class="settings-item">
@@ -161,7 +161,7 @@
                 </strong>
                 <div>
                   <label class="checkbox">
-                    <input data-for="minimap" type="checkbox" />
+                    <input name="minimap" type="checkbox" />
                     <span>Controls whether the minimap is shown.</span>
                   </label>
                 </div>
@@ -174,7 +174,7 @@
                 </strong>
                 <div>
                   <label class="checkbox">
-                    <input data-for="fontLigatures" type="checkbox" />
+                    <input name="fontLigatures" type="checkbox" />
                     <span>Controls whether the ligatures is enabled.</span>
                   </label>
                 </div>
@@ -187,13 +187,28 @@
                 </strong>
                 <div>
                   <span>Change view layout</span>
-                  <div class="layout-preview-container">
-										<layout-preview layout="default"></layout-preview>
-										<layout-preview layout="layout-2"></layout-preview>
-										<layout-preview layout="vertical"></layout-preview>
-										<layout-preview layout="horizontal"></layout-preview>
-										<layout-preview layout="bottom"></layout-preview>
-                  </div>
+                  <fieldset class="layout-preview-container">
+                    <label for="default-layout-radio">
+                      <input type="radio" name="layout" value="default">
+                      <layout-preview layout="default"></layout-preview>
+                    </label>
+                    <label for="layout-2-layout-radio">
+                      <input type="radio" name="layout" value="layout-2">
+                      <layout-preview layout="layout-2"></layout-preview>
+                    </label>
+                    <label for="vertical-layout-radio">
+                      <input type="radio" name="layout" value="vertical">
+                      <layout-preview layout="vertical"></layout-preview>
+                    </label>
+                    <label for="horizontal-layout-radio">
+                      <input type="radio" name="layout" value="horizontal">
+                      <layout-preview layout="horizontal"></layout-preview>
+                    </label>
+                    <label for="bottom-layout-radio">
+                      <input type="radio" name="layout" value="bottom">
+                      <layout-preview layout="bottom"></layout-preview>
+                    </label>
+                  </fieldset>
                 </div>
               </div>
               <div class="settings-item">
@@ -203,7 +218,7 @@
                 </strong>
                 <div>
                   <label class='checkbox'>
-                    <input data-for="preserveGrid" type='checkbox' />
+                    <input name="preserveGrid" type='checkbox' />
                     <span>Controls whether the grid template is preserved.</span>
                   </label>
                 </div>
@@ -215,7 +230,7 @@
                   File name
                 </strong>
                 Set the zip file name.
-                <input data-for="zipFileName" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" wrap="off" value="codi.link" required>
+                <input name="zipFileName" class="input" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" wrap="off" value="codi.link" required>
               </div>
 
               <div class="settings-item">
@@ -225,14 +240,14 @@
                 </strong>
                 <div>
                   <label class='checkbox'>
-                    <input data-for="zipInSingleFile" type='checkbox' />
+                    <input name="zipInSingleFile" type='checkbox' />
                     <span>Controls whether export one single zipped HTML file.</span>
                   </label>
                 </div>
               </div>
 
             </div>
-          </div>
+          </form>
         </div>
       </aside>
 

--- a/src/main.js
+++ b/src/main.js
@@ -44,16 +44,9 @@ const EDITORS = Array.from(editorElements).reduce((acc, domElement) => {
 }, {})
 
 subscribe(state => {
+  const newOptions = { ...state, minimap: { enabled: state.minimap } }
+
   Object.values(EDITORS).forEach(editor => {
-    const { minimap, ...restOfOptions } = state
-
-    const newOptions = {
-      ...restOfOptions,
-      minimap: {
-        enabled: minimap
-      }
-    }
-
     editor.updateOptions({
       ...editor.getRawOptions(),
       ...newOptions

--- a/src/style.css
+++ b/src/style.css
@@ -64,6 +64,12 @@ iframe {
   width: 100%;
 }
 
+fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
 /* Temporal hack to be able to copy icons to dist folder */
 /* ToDo: move it to codi-editor component */
 codi-editor[language=html]::after {
@@ -722,6 +728,21 @@ select {
       display: flex;
       justify-content: space-between;
       padding: 10px 0;
+
+      & label {
+        position: relative;
+
+        & input[type="radio"] {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          top: 0;
+          left: 0;
+          margin: 0;
+          padding: 0;
+          opacity: 0;
+        }
+      }
     }
 
   }

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,3 +1,7 @@
+/**
+ * @param {string} selector
+ * @param {ParentNode} context
+ */
 export const $ = (selector, context = document) =>
   context.querySelector(selector)
 
@@ -6,6 +10,7 @@ export const $$ = (selector, context = document) =>
 
 export const isNodeSelect = el => el.nodeName === 'SELECT'
 export const isNodeCheckbox = el => el.nodeName === 'INPUT' && el.type === 'checkbox'
+export const isNodeRadio = el => el.nodeName === 'INPUT' && el.type === 'radio'
 
 const updateSelectValue = (el, value) => {
   const optionToSelect = el.querySelector(`option[value="${value}"]`)
@@ -16,8 +21,9 @@ const updateSelectValue = (el, value) => {
 export const setFormControlValue = (el, value) => {
   const isSelect = isNodeSelect(el)
   const isCheckbox = isNodeCheckbox(el)
+  const isRadio = isNodeRadio(el)
 
   if (isSelect) updateSelectValue(el, value)
-  else if (isCheckbox) el.checked = value
+  else if (isCheckbox || isRadio) el.checked = value
   else el.value = value
 }


### PR DESCRIPTION
This PR changes the code of the settings to use native form APIs.

- Use a form element to wrap the settings form.
- Replace the custom `data-for` attribute with native `name` attribute for naming form controls.
- Use event delegation by attaching listeners to `input` and `change` events to the form element itself.
- Use `radio` inputs for the layout settings instead of attaching click listeners to the LayoutPreview elements. Hence there is no need for using a different way to retrieve that setting with the click event.

This changes results in more cleaner and maintainable code by using the standard API for handling forms.