### PR TITLE
Add copy button on skypack packages

### DIFF
--- a/src/events-controller.js
+++ b/src/events-controller.js
@@ -26,7 +26,7 @@ export const EVENTS = {
 }
 
 eventBus.on(EVENTS.ADD_SKYPACK_PACKAGE, ({ skypackPackage, url }) => {
-  const importStatement = `import ${capitalize(skypackPackage)} from '${url}';`
+  const importStatement = `import ${capitalize(skypackPackage).replaceAll('.', '_')} from '${url}';`
   const existPackage = searchByLine(jsEditor.getValue(), url)
   if (!existPackage) {
     jsEditor.setValue(`${importStatement}\n${jsEditor.getValue()}`)

--- a/src/skypack.js
+++ b/src/skypack.js
@@ -118,9 +118,18 @@ function displayResults ({ results, searchTerm }) {
     $li.innerHTML = getResultHTML({ result, searchTerm })
     $li.tabIndex = 0
 
+    const url = `${CDN_URL}/${result.name}`
+
     $li.addEventListener('click', (e) => {
-      if (e.target.className === 'skypack-open') return
-      handlePackageSelected(result.name)
+      if (e.target.className === 'skypack-open') {
+        if (e.target.hasAttribute('data-copy')) {
+          e.preventDefault()
+          navigator.clipboard.writeText(url)
+        }
+        return
+      }
+
+      handlePackageSelected(result.name, url)
     })
     $li.addEventListener('keydown', (e) => {
       if (e.keyCode === 13) handlePackageSelected(result.name)
@@ -141,7 +150,10 @@ function getResultHTML ({ result, searchTerm }) {
     <section class="skypack-description">${escapeHTML(result.description)}</section>
     <footer>
       <div class="skypack-updated" >Updated: ${updatedAt}</div>
-      <a tabindex="-1" class="skypack-open" target="_blank" href="${PACKAGE_VIEW_URL}/${result.name}">details</a>
+      <div>
+        <a tabindex="-1" class="skypack-open" data-copy target="_blank" href="${CDN_URL}/${result.name}">copy</a>
+        <a tabindex="-1" class="skypack-open" target="_blank" href="${PACKAGE_VIEW_URL}/${result.name}">details</a>
+      </div>
     </footer>`
 }
 
@@ -160,10 +172,10 @@ function getResultBadgesHTML ({ result, searchTerm }) {
     </div>`
 }
 
-function handlePackageSelected (packageName) {
+function handlePackageSelected (packageName, packageUrl) {
   let parsedName = packageName.split('/').join('-')
   if (parsedName.startsWith('@')) parsedName = parsedName.substr(1)
-  eventBus.emit(EVENTS.ADD_SKYPACK_PACKAGE, { skypackPackage: parsedName, url: `${CDN_URL}/${packageName}` })
+  eventBus.emit(EVENTS.ADD_SKYPACK_PACKAGE, { skypackPackage: parsedName, url: packageUrl })
 }
 
 function createLoadMoreResultsSentinelObserver ($sentinelEl) {


### PR DESCRIPTION
### The problem

Usually you want to import a dependency which is not a JavaScript file but CSS. In that case if you click the package you end up with this for example (using normalize.css):

![image](https://user-images.githubusercontent.com/39559632/147887991-0d1c6da5-3a67-4061-a061-ae5b5ac9952b.png)


### The solution

For those cases, this PR adds a button to copy the package URL to the clipboard so you can paste it into a `link` tag, an `@import` on the CSS, or even a dynamic `import()` on the JavaScript.

![image](https://user-images.githubusercontent.com/39559632/147888191-7996f406-ae0b-47dc-9a40-70c2320dcff8.png)

![image](https://user-images.githubusercontent.com/39559632/147888327-db6584c8-0191-4df4-ae09-58d2bbc54cda.png)

![image](https://user-images.githubusercontent.com/39559632/147888340-63a49c12-9ee2-4474-b732-d92d204a9670.png)


I also made that in the import name the dots are replaced by underscores. 
![image](https://user-images.githubusercontent.com/39559632/147888283-a5791499-daa2-4dba-8c43-ea228eec2154.png)


