### PR TITLE
Icons transparent on editor hover or focus

### DIFF
--- a/src/components/codi-editor/CodiEditor.styles.js
+++ b/src/components/codi-editor/CodiEditor.styles.js
@@ -18,6 +18,15 @@ export const CodiEditorStyles = css`
     pointer-events: none;
   }
 
+  slot:hover + img {
+   opacity: 0.2;
+  }
+  
+   slot:focus-within + img {
+    opacity: 0.1;
+  }
+  
+
   @media (max-width: 650px) {
     :host::after {
       left: 16px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39559632/152467464-a95483e1-5678-49c9-9a72-dec27319619f.png)

This makes easier to see the code below the icons