### PR TITLE
Fix layout resizing

### DIFF
--- a/src/grid.js
+++ b/src/grid.js
@@ -1,4 +1,6 @@
 import Split from 'split-grid'
+import { DEFAULT_GRID_TEMPLATE, EDITOR_GRID_TEMPLATE } from './constants/editor-grid-template'
+import { BOTTOM_LAYOUT, DEFAULT_LAYOUT, HORIZONTAL_LAYOUT, VERTICAL_LAYOUT } from './constants/grid-templates'
 import { getState } from './state'
 import { $, $$ } from './utils/dom'
 
@@ -35,7 +37,15 @@ const getInitialGridStyle = () => {
   return gridTemplate && `grid-template-columns: ${gridTemplate['grid-template-columns']}; grid-template-rows: ${gridTemplate['grid-template-rows']}`
 }
 
-const setGridLayout = ({ gutters, style, type = '' }) => {
+const setGridLayout = (type = '') => {
+  const style = EDITOR_GRID_TEMPLATE[type] || DEFAULT_GRID_TEMPLATE
+
+  const gutters = {
+    vertical: VERTICAL_LAYOUT,
+    horizontal: HORIZONTAL_LAYOUT,
+    bottom: BOTTOM_LAYOUT
+  }[type] ?? DEFAULT_LAYOUT
+
   const initialStyle = !splitInstance && getInitialGridStyle()
 
   $editor.setAttribute('data-layout', type)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,5 +1,3 @@
-import { DEFAULT_GRID_TEMPLATE, EDITOR_GRID_TEMPLATE } from './constants/editor-grid-template.js'
-import { DEFAULT_LAYOUT, HORIZONTAL_LAYOUT, VERTICAL_LAYOUT, BOTTOM_LAYOUT } from './constants/grid-templates.js'
 import { getState } from './state.js'
 import { $, setFormControlValue } from './utils/dom.js'
 
@@ -47,24 +45,11 @@ function updateSettingValue ({ target }) {
   const isCheckbox = target.type === ELEMENT_TYPES.CHECKBOX
   const isRadio = target.type === ELEMENT_TYPES.RADIO
 
-  let settingValue = isCheckbox ? checked : value
+  const settingValue = isCheckbox ? checked : value
 
   if (isRadio) {
     if (!checked) { return }
-    settingValue = getLayoutValue(value)
   }
 
   updateSettings({ key: settingKey, value: settingValue })
-}
-
-function getLayoutValue (layout) {
-  const style = EDITOR_GRID_TEMPLATE[layout] || DEFAULT_GRID_TEMPLATE
-
-  const gutters = {
-    vertical: VERTICAL_LAYOUT,
-    horizontal: HORIZONTAL_LAYOUT,
-    bottom: BOTTOM_LAYOUT
-  } ?? DEFAULT_LAYOUT
-
-  return { gutters, style, type: layout }
 }


### PR DESCRIPTION
- The gutters value was being set incorrectly.
- Move the logic of obtaining grid configs to the grid.js file instead of the settings.js
- Store only the layout name on the state.

closes: #195