### PR TITLE
Set Headway changelog badge to 20px

### DIFF
--- a/src/css/notifications.css
+++ b/src/css/notifications.css
@@ -108,4 +108,11 @@
   position: absolute !important;
   top: 0 !important;
   right: 0 !important;
+  width: 20px !important;
+  height: 20px !important;
+}
+
+.HW_badge {
+  top: 2px !important;
+  left: 2px !important;
 }


### PR DESCRIPTION
- [x] Make the badge smaller so it does not interfere with settings icon.

![2022-04-12 (3)](https://user-images.githubusercontent.com/7684330/163024518-d11be33b-8b5e-40fd-ac10-4598435d0e31.png)
![2022-04-12 (2)](https://user-images.githubusercontent.com/7684330/163024521-6aad8c5b-90e7-4bc8-9de7-fe3422ed8b67.png)
 
This fixes #199