### PR TITLE
fix: Added missing closing tags in Settings item

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,12 +451,16 @@
               </div>
               <div class="settings-item">
                 <strong>
-                  <span class="settings-type">Features › autosave localstorage
+                  <span class="settings-type"
+                    >Features › autosave localstorage</span
+                  >
+                </strong>
                 <div>
                   <label class="checkbox">
                     <input name="saveLocalstorage" type="checkbox" />
                     <span
-                      >Automatically save URL to local storage for fast content loading</span
+                      >Automatically save URL to local storage for fast content
+                      loading</span
                     >
                   </label>
                 </div>
@@ -526,9 +530,9 @@
 
     <script>
       var HW_config = {
-        selector: '.aside-sections footer button:last-child',
-        account: 'x8YRn7'
-      }
+        selector: ".aside-sections footer button:last-child",
+        account: "x8YRn7",
+      };
     </script>
     <script async src="https://cdn.headwayapp.co/widget.js"></script>
   </body>


### PR DESCRIPTION
Había un "setting- item" sin las correspondientes etiquetas de cierre, lo que provocaba que no se viese los estilos correctamente.