### PR TITLE
Determinar dinámicamente el delimitador en el nombre de la ruta

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ if (pathname === '/' && saveLocalstorage === true) {
   pathname = window.location.pathname
 }
 
-const [rawHtml, rawCss, rawJs] = pathname.slice(1).split('%7C')
+const [rawHtml, rawCss, rawJs] = pathname.slice(1).split(pathname.includes('%7C') ? '%7C' : '|')
 
 const VALUES = {
   html: rawHtml ? decode(rawHtml) : '',


### PR DESCRIPTION
En algunos navegadores el caracter "|" no se encodea por lo que al intentar hacer el split de la ruta esta genera errores que no permiten una correcta renderizacion del css y js
![codi_link1](https://github.com/midudev/codi.link/assets/62715495/2dfecd5d-dc12-4ebd-bbb9-147dd06f50ae)
![codi_link2_error](https://github.com/midudev/codi.link/assets/62715495/2a697cfc-e17a-4579-b69c-02e87e0fc263)
