### PR TITLE
Fix console line number calculation

### DIFF
--- a/src/console-script.js
+++ b/src/console-script.js
@@ -1,4 +1,4 @@
-export const generateConsoleScript = () => {
+export const generateConsoleScript = ({ html, css }) => {
   return `<script>
     const customConsole = (w) => {
       const pushToConsole = (payload, type) => {
@@ -13,7 +13,11 @@ export const generateConsoleScript = () => {
       pushToConsole("clear", "system")
 
       w.onerror = (message, url, line, column) => {
-        pushToConsole({line, column, message}, "error")
+        const DEFAULT_LINE_HEIGHT = 53
+        const htmlLines = ${html.split('\n').length}
+        const cssLines = ${css.split('\n').length}
+        const fixedLine = line - DEFAULT_LINE_HEIGHT - htmlLines - cssLines
+        pushToConsole({line:fixedLine, column, message}, "error")
       }
 
       const console = {

--- a/src/utils/createHtml.js
+++ b/src/utils/createHtml.js
@@ -20,12 +20,12 @@ export const createHtml = ({ css, html, js }, isEditor = false) => {
     <style id="preview-style">
       ${css}
     </style>
-    ${isEditor ? generateConsoleScript() : ''}
+    ${isEditor ? generateConsoleScript({ html, css }) : ''}
   </head>
   <body>
     ${html}
     <script type="module">
-    ${js}
+${js}
     </script>
   </body>
 </html>`


### PR DESCRIPTION
This pull request fixes the console line number calculation in the generateConsoleScript function. Previously, the line number was not accurately calculated when an error occurred.
This PR updates the calculation to account for the number of lines in the HTML and CSS code.

Before:
![image](https://github.com/midudev/codi.link/assets/86802432/999214e2-88cb-48c0-b6cb-93f3a896298f)

After:
![image](https://github.com/midudev/codi.link/assets/86802432/eb13937a-2436-4894-bf76-4143d58fa2bc)
