### PR TITLE
Override CTRL+S on window and iframe

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import setTheme from './theme.js'
 import { configurePrettierHotkeys } from './monaco-prettier/configurePrettier'
 import { getHistoryState, subscribeHistory, setHistory } from './history.js'
 
+import './overridekbd.js'
 import './aside.js'
 import './skypack.js'
 import './settings.js'

--- a/src/overridekbd.js
+++ b/src/overridekbd.js
@@ -1,0 +1,5 @@
+window.addEventListener('keydown', (event) => {
+  if (event.ctrlKey && event.key === 's') {
+    event.preventDefault()
+  }
+})

--- a/src/utils/createHtml.js
+++ b/src/utils/createHtml.js
@@ -25,8 +25,13 @@ export const createHtml = ({ css, html, js }, isEditor = false) => {
   <body>
     ${html}
     <script type="module">
-${js}
-    </script>
+    window.addEventListener('keydown', (event) => {
+      if (event.ctrlKey && event.key === 's') {
+        event.preventDefault()
+      }
+    });
+  ${js}
+  </script>
   </body>
 </html>`
 }


### PR DESCRIPTION
Override the CTRL+S shorcut so that browsers don't try to download the page

![Pressing CTRL+S on chrome opens save window](https://github.com/midudev/codi.link/assets/58951699/89f6bb5f-61c7-4839-b10f-75885b0681f7)
_(dialog opened after pressing CTRL+S on any part of the website)_

Solution for the Iframe is embedded directly into the createHtml template string, which I don't think is an ideal solution (but I couldn't get addEventListener to work on the iframe) if any better solution is found I'll close the PR