### PR TITLE
Fix URL concatenation in copyToClipboard function

### DIFF
--- a/src/aside.js
+++ b/src/aside.js
@@ -24,7 +24,7 @@ const SIMPLE_CLICK_ACTIONS = {
 
   [BUTTON_ACTIONS.copyToClipboard]: async () => {
     const url = new URL(window.location.href)
-    const urlToCopy = `https://codi.link/${url.pathname}`
+    const urlToCopy = `https://codi.link${url.pathname}`
     copyToClipboard(urlToCopy)
   },
 


### PR DESCRIPTION
![image](https://github.com/midudev/codi.link/assets/39859315/b6206c23-020c-4980-b823-4ca694747eb3)
Ejemplo de como cambia el link al  usar el clipboard:
https://codi.link//PGJvZHk+DQogIDxkaXYgaWQ9ImNvb...
![image](https://github.com/midudev/codi.link/assets/39859315/f4b06619-2a4f-4d3c-bc86-1e69d084974c)
