### PR TITLE
Fix: Duplicated slash at copy button & shortcut

### DIFF
--- a/src/aside.js
+++ b/src/aside.js
@@ -24,7 +24,7 @@ const SIMPLE_CLICK_ACTIONS = {
 
   [BUTTON_ACTIONS.copyToClipboard]: async () => {
     const url = new URL(window.location.href)
-    const urlToCopy = `https://codi.link/${url.pathname}`
+    const urlToCopy = `https://codi.link${url.pathname}`
     copyToClipboard(urlToCopy)
   },
 

--- a/src/components/codi-editor/extensions/editor-hotkeys.js
+++ b/src/components/codi-editor/extensions/editor-hotkeys.js
@@ -23,7 +23,7 @@ export const initEditorHotKeys = (editor) => {
     monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyC,
     () => {
       const url = new URL(window.location.href)
-      const urlToCopy = `https://codi.link/${url.pathname}`
+      const urlToCopy = `https://codi.link${url.pathname}`
       copyToClipboard(urlToCopy)
     }
   )


### PR DESCRIPTION
# Description
Fixed a bug in the copy URL action that added an additional slash to the URL, making HTML buggy.

# Example
Original:
![imagen](https://github.com/midudev/codi.link/assets/55891793/48d6534c-81a8-4b6c-8965-489db5f9374f)

Opening link after copying link with button or action:
![imagen](https://github.com/midudev/codi.link/assets/55891793/f3eb025e-0972-4b1f-a703-6900751c84ef)

# Proposal
Change the copy actions to copy the actual location, enabling functionality even when on localhost.
