### PR TITLE
Add color variants to improve usability on lighter themes

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,6 +1,6 @@
 :root {
   --app-background: rgb(30, 30, 30);
-  --app-foreground: rgb(51, 51, 51);
+  --app-foreground: rgb(204, 204, 204);
 
   --aside-sections-background: rgb(51, 51, 51);
   --aside-sections-border: transparent;
@@ -21,6 +21,11 @@
   --input-background: rgb(51, 51, 51);
   --input-foreground: rgb(225, 228, 232);
   --input-border: rgb(51, 51, 51);
+
+  --log-log: rgb(205, 238, 181);
+  --log-info: rgb(181, 181, 238);
+  --log-error: rgb(227, 189, 189);
+  --log-warn: rgb(247, 231, 161);
 }
 
 [data-theme='vs'] {
@@ -39,6 +44,11 @@
   --input-background: rgb(243, 243, 243);
   --input-foreground: rgb(97, 97, 97);
   --input-border: rgb(97, 97, 97);
+
+  --log-log: rgb(14, 197, 8);
+  --log-info: rgb(31, 76, 226);
+  --log-error: rgb(219, 14, 14);
+  --log-warn: rgb(203, 168, 8);
 }
 
 [data-theme='hc-black'] {
@@ -90,6 +100,11 @@
   --input-background: rgb(255, 255, 255);
   --input-foreground: rgb(0, 0, 0);
   --input-border: rgb(0, 0, 0);
+
+  --log-log: rgb(7, 154, 2);
+  --log-info: rgb(6, 53, 210);
+  --log-error: rgb(223, 0, 0);
+  --log-warn: rgb(178, 145, 0);
 }
 
 body {

--- a/src/css/console.css
+++ b/src/css/console.css
@@ -1,6 +1,7 @@
 .console {
   & .console-header {
     background: var(--aside-bar-background);
+    color: var(--app-foreground);
     position: sticky;
     top: 0;
     z-index: 1;
@@ -56,6 +57,7 @@
       color: black;
       padding-top: 0.5em
     }
+
     & .error::before {
       content: '❗';
       margin-right: 4px;
@@ -63,16 +65,19 @@
     }
 
     & .log-log {
-      color: rgb(205, 238, 181);
+      color: var(--log-log)
     }
+
     & .log-info {
-      color: rgb(181, 181, 238);
+      color: var(--log-info)
     }
+
     & .log-error {
-      color: rgb(227, 189, 189);
+      color: var(--log-error)
     }
+
     & .log-warn {
-      color: rgb(247, 231, 161);
+      color: var(--log-warn)
     }
   }
 }


### PR DESCRIPTION
No CSS properties where define for the colors on the console, rendering logs with low contrasts on light themes. Added custom properties con base and console css files