### PR TITLE
Fix Fraction Explosion

### DIFF
--- a/src/css/editors-layout.css
+++ b/src/css/editors-layout.css
@@ -9,8 +9,18 @@
   height: 100vh;
 
   [data-layout='default'] & {
+    & .first-gutter {
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
+    }
     & .second-gutter {
       background: transparent;
+    }
+    & .last-gutter {
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
   }
   [data-layout='layout-2'] & {
@@ -19,8 +29,18 @@
       '. . .'
       'editor-js . editor-preview';
 
+    & .first-gutter {
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
+    }
     & .second-gutter {
       background: transparent;
+    }
+    & .last-gutter {
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
   }
   [data-layout='vertical'] & {
@@ -28,16 +48,25 @@
     & .first-gutter {
       cursor: col-resize;
       grid-area: 1 / 2 / 1 / 2;
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
     & .second-gutter {
       cursor: col-resize;
       grid-area: 1 / 4 / 1 / 4;
       background-image: url(/assets/vertical.png);
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
     & .last-gutter {
       cursor: col-resize;
       grid-area: 1 / 6 / 1 / 6;
       background-image: url(/assets/vertical.png);
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
   }
   [data-layout='horizontal'] & {
@@ -53,15 +82,24 @@
       grid-area: 2 / 1 / 2 / 1;
       cursor: row-resize;
       background-image: url(/assets/horizontal.png);
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
     & .second-gutter {
       grid-area: 4 / 1 / 4 / 1;
       cursor: row-resize;
       background-image: url(/assets/horizontal.png);
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
     & .last-gutter {
       grid-area: 6 / 1 / 6 / 1;
       cursor: row-resize;
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
   }
   [data-layout='bottom'] & {
@@ -74,15 +112,24 @@
     & .first-gutter {
       cursor: col-resize;
       grid-area: 2 / 2 / 4 / 3;
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
     & .second-gutter {
       cursor: col-resize;
       grid-area: 2 / 4 / 4 / 5;
       background-image: url(/assets/vertical.png);
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
     & .last-gutter {
       cursor: row-resize;
       grid-area: 2 / 1 / 2 / 6;
+      position: relative;
+      box-shadow: 0 -1px 0 0 var(--grid-background),
+        0 1px 0 0 var(--grid-background);
     }
   }
 

--- a/src/grid.js
+++ b/src/grid.js
@@ -82,6 +82,7 @@ const setGridLayout = (type = '') => {
     ...(gutters.rowGutters && {
       rowGutters: gutters.rowGutters.map(formatGutters)
     }),
+    minSize: 1,
     onDragEnd: saveGridTemplate
   }
 


### PR DESCRIPTION
Hola! 👋
Esta es mi primer Pull Request en GitHub! 😅

Codi.link es excelente, pero al cambiar el tamaño de los editores utilizando el drag a veces ocurre un bug que contrae los demás editores aleatoriamente, lo cual es bastante molesto.

Demo del error con un [video de Midu 😎](https://www.youtube.com/watch?v=iTjkiI8QQsM)

[Video](https://github.com/user-attachments/assets/e195b70c-8e23-4c4c-afcf-0aaf62ca93fe)


Creo que este error se genera cuando uno de los editores o "tracks" se contrae por completo. La dependencia de split-grid le asigna un fraction con valor de 0.

Después cuando la dependencia intenta calcular nuevamente el valor de los fraction (realiza una división) al tener un valor de 0 esto genera que los fraction restantes tomen valores muy elevados. Ahí es cuando el layout se rompe y empieza a volverse loco.

![bug](https://github.com/user-attachments/assets/a9d78a5b-54dd-42fd-a164-3f83bad673c1)

Otra demo de este bug puede verse en esta [issue de split-grid](https://github.com/nathancahill/split/issues/797)





Para solucionarlo establezco el tamaño mínimo de los "tracks" a 1px, para prevenir el valor default de 0fr.
Con esto la librería devuelve fractions muy pequeños, pero siempre mayores a cero. 


![solution](https://github.com/user-attachments/assets/63cc719f-8ebb-4ada-8713-e6b0fc254e5d)


Ahora al tener editores ("tracks") de un 1px de tamaño como mínimo, ya no se generan valores de fractions exponenciales por el bug, pero se ya no se pueden apilar los draggers entre sí, siempre va a quedar 1px en cada lado.

![problem](https://github.com/user-attachments/assets/2e937246-5576-46d0-ab62-d5c9621317f2)



Para solucionar este segudo problema, le agregué a los draggers o "gutters" un box-shadow con CSS para cubrir esos pixeles sobrantes.

![shadow](https://github.com/user-attachments/assets/310c4c4b-71a6-4cf8-b47b-6cc90486ecb2)


Eso sería todo 😅
