### PR TITLE
Fix fraction calculation in tabs layout

### DIFF
--- a/src/css/editors-layout.css
+++ b/src/css/editors-layout.css
@@ -145,6 +145,9 @@
       cursor: col-resize;
       background-image: url(/assets/vertical.png);
       grid-area: 1 / 2 / 3 / 2;
+      position: relative;
+      box-shadow: -1px 0 0 0 var(--grid-background),
+        1px 0 0 0 var(--grid-background);
     }
     & .second-gutter,
     & .last-gutter {

--- a/src/grid.js
+++ b/src/grid.js
@@ -128,6 +128,7 @@ const setGridLayout = (type = '') => {
     ...(gutters.rowGutters && {
       rowGutters: gutters.rowGutters.map(formatGutters)
     }),
+    ...(type === 'tabs' && { columnMinSizes: { 0: 300 } }),
     minSize: 1,
     onDragEnd: saveGridTemplate
   }


### PR DESCRIPTION
Solución de este bug que contrae las cuadrículas del grid:

https://github.com/user-attachments/assets/4a2e1e27-56db-4715-b107-d4e66826aef9



También le agregué con CSS un píxel de sombra al gutter en cada costado para poder desplazarlo al máximo.

Configuré el tamaño mínimo en 300px para el editor, es un poco más de lo que ocupa el min-content del selector de pestañas. Si les parece poco o mucho, se puede cambiar fácilmente modificando esa línea del JS.

