### PR TITLE
fix: error when dragging something that is not a file

### DIFF
--- a/src/drag-file.js
+++ b/src/drag-file.js
@@ -31,6 +31,12 @@ window.addEventListener('dragleave', ({ clientX, clientY }) => {
   }
 })
 
+window.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    $overlayDrag.classList.add('hidden')
+  }
+})
+
 function readFiles (e) {
   const { files } = e.dataTransfer
   Object.values(files).forEach(file => {


### PR DESCRIPTION
This pull request includes an update to `src/drag-file.js` to enhance the user experience when interacting with the drag-and-drop file overlay.

* [`src/drag-file.js`](diffhunk://#diff-fc762f816a54848c5699896a1f510c933b39fd3910bec24e44b41b8b968e9635R34-R39): Added a `visibilitychange` event listener to hide the drag overlay when the document becomes hidden.

When the user drop something that is not a file and the browser launch a new tab, the overlay doesn not hide because the `dragleave` event is not being called.

That behavior happens with dropped links, emails (from the Apple mail app), files from VSCode (because they are drop as a string with the route), and possibly many more.

Before the change:

https://github.com/user-attachments/assets/bfdf08c8-1345-4a1e-aa90-a0442475fe5c

After the change:

https://github.com/user-attachments/assets/caf53346-e9df-452c-83b3-2e4942663d58

