### PR TITLE
Fix: Evitar que console.log renderice HTML/XML en templates multilínea

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -79,9 +79,18 @@ const createListItem = (content, type) => {
   $pre.style.whiteSpace = 'pre-wrap'
   $pre.style.margin = '0'
 
+  const containsHtmlTags = (str) => {
+    return typeof str === 'string' && /<[a-zA-Z][^>]*>/.test(str)
+  }
   // innerHTML en lugar de textContent para que deje formatear
-  if (typeof content === 'string' && (content.includes('<span') || content.includes('\n'))) {
-    $pre.innerHTML = content
+  if (typeof content === 'string' && (containsHtmlTags(content) || content.includes('\n'))) {
+    if (containsHtmlTags(content)) {
+      const tempDiv = document.createElement('div')
+      tempDiv.textContent = content
+      $pre.textContent = tempDiv.textContent
+    } else {
+      $pre.textContent = content
+    }
   } else {
     $pre.textContent = content
   }


### PR DESCRIPTION
## Mejorar la visualización de templates multilinea en console.log

### Contexto

Actualmente, al hacer `console.log` de un **template string multilínea** que contiene **etiquetas XML o HTML**, el contenido se procesa de manera inesperada:

- Las **etiquetas desaparecen**, dejando solo el contenido interno.
- Si es HTML válido, la consola puede **renderizar** ese HTML, lo que genera resultados inesperados (por ejemplo, textos en **negrita** si son etiquetas `<h1>`, `<h2>`, etc).
- En cambio, si el template está en una **sola línea**, se muestra correctamente como string.

![image](https://github.com/user-attachments/assets/df262d2e-2ce2-4cc2-a5da-6212699e7bc1)

---

### Solución

Con el ajuste que propongo:

- Se asegura que **siempre** se imprima el contenido **literal** del string, incluyendo todas las etiquetas XML/HTML, sin que el navegador intente interpretarlas o renderizarlas.
- Esto es útil para debuggear templates, peticiones XML, estructuras HTML, etc.

![image](https://github.com/user-attachments/assets/924f0371-824d-4545-8448-c6e5e8f8aeba)

---

### Ejemplo de Comportamiento

**Antes:**
```js
const html = `<div> 
  <h1>Hola</h1>
  <h2>Bienvenido</h2>
</div>`

console.log(html)
// Resultado: Hola y Bienvenido aparecen renderizados como títulos (negrita)
```

**Después de la corrección:**
```js
const html = `<div> 
  <h1>Hola</h1>
  <h2>Bienvenido</h2>
</div>`

console.log(html)
// Resultado: el texto se muestra tal cual, con todas las etiquetas visibles
```

---

### Notas Técnicas

- No se modifica el comportamiento de `console.log` en casos normales (cadenas simples, números, objetos).
- Solo afecta la manera de imprimir strings con contenido potencialmente interpretado como XML/HTML en entorno de navegador.
- La corrección es backwards-compatible.