### PR TITLE
Add new editor themes (Dracula, One Dark Pro, Mosqueta)

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,6 +393,9 @@
                   <option data-translate="light" value="vs">Light</option>
                   <option data-translate="highContrastDark" value="hc-black">High Contrast Dark</option>
                   <option data-translate="highContrastLight" value="hc-light">High Contrast Light</option>
+                  <option value="one-dark-pro">One Dark Pro</option>
+                  <option value="dracula">Dracula</option>
+                  <option value="mosqueta-dark">Mosqueta Dark</option>
                 </select>
               </div>
             </div>

--- a/src/components/codi-editor/CodiEditor.js
+++ b/src/components/codi-editor/CodiEditor.js
@@ -8,6 +8,7 @@ import JsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAutoCompleteHTMLTag } from './extensions/autocomplete-html-tag.js'
 import { initEditorHotKeys } from './extensions/editor-hotkeys.js'
 import { CodiEditorStyles } from './CodiEditor.styles.js'
+import { registerThemes } from './extensions/register-themes.js'
 
 const iconUrls = {
   css: new URL('../../../assets/css.svg', import.meta.url),
@@ -68,6 +69,7 @@ export class CodiEditor extends LitElement {
         }
       }
 
+      registerThemes(monaco)
       emmetHTML(monaco)
       registerAutoCompleteHTMLTag(monaco)
       this.editorInitialized = true

--- a/src/components/codi-editor/extensions/register-themes.js
+++ b/src/components/codi-editor/extensions/register-themes.js
@@ -1,0 +1,7 @@
+import themesJson from '../themes.json'
+
+export function registerThemes (monaco) {
+  Object.entries(themesJson).forEach(([themeName, themeDef]) => {
+    monaco.editor.defineTheme(themeName, themeDef)
+  })
+}

--- a/src/components/codi-editor/themes.json
+++ b/src/components/codi-editor/themes.json
@@ -1,0 +1,159 @@
+{
+    "one-dark-pro": {
+        "label": "One Dark Pro",
+        "base": "vs-dark",
+        "inherit": true,
+        "semanticHighlighting": true,
+        "rules": [
+            {
+                "token": "comment",
+                "foreground": "#7f8590",
+                "fontStyle": "italic"
+            },
+            {
+                "token": "keyword",
+                "foreground": "#c779dc"
+            },
+            {
+                "token": "number",
+                "foreground": "#d19a66"
+            },
+            {
+                "token": "string",
+                "foreground": "#99c27a"
+            },
+            {
+                "token": "storage",
+                "foreground": "#ffad66"
+            },
+            {
+                "token": "identifier",
+                "foreground": "#62afef"
+            },
+            {
+                "token": "tag",
+                "foreground": "#e06c75"
+            },
+            {
+                "token": "attribute.value",
+                "foreground": "#99c27a"
+            },
+            {
+                "token": "attribute.name",
+                "foreground": "#d19a66"
+            },
+            {
+                "token": "selector.class",
+                "foreground": "#d19a66"
+            }
+        ],
+        "colors": {
+            "editor.background": "#282b34",
+            "editor.lineHighlightBackground": "#2e313d"
+        }
+    },
+    "dracula": {
+        "base": "vs-dark",
+        "inherit": true,
+        "label": "Dracula",
+        "rules": [
+            {
+                "token": "comment",
+                "foreground": "#5b72a4",
+                "fontStyle": "italic"
+            },
+            {
+                "token": "keyword",
+                "foreground": "#fe7bc8"
+            },
+            {
+                "token": "number",
+                "foreground": "#bf95f9"
+            },
+            {
+                "token": "string",
+                "foreground": "#e5fb8e"
+            },
+            {
+                "token": "storage",
+                "foreground": "#ffad66"
+            },
+            {
+                "token": "identifier",
+                "foreground": "#bf95f9"
+            },
+            {
+                "token": "tag",
+                "foreground": "#fe7bc8"
+            },
+            {
+                "token": "attribute.value",
+                "foreground": "#e5fb8e"
+            },
+            {
+                "token": "attribute.name",
+                "foreground": "#50fb7b"
+            },
+            {
+                "token": "selector.class",
+                "foreground": "#d19a66"
+            }
+        ],
+        "colors": {
+            "editor.background": "#2a2c37",
+            "editor.lineHighlightBackground": "#2a2c37"
+        }
+    },
+    "mosqueta-dark": {
+        "base": "vs-dark",
+        "inherit": true,
+        "label": "Mosqueta Dark",
+        "rules": [
+            {
+                "token": "comment",
+                "foreground": "#6272a4",
+                "fontStyle": "italic"
+            },
+            {
+                "token": "keyword",
+                "foreground": "#e67cbe"
+            },
+            {
+                "token": "number",
+                "foreground": "#ffec80"
+            },
+            {
+                "token": "string",
+                "foreground": "#f8ff97"
+            },
+            {
+                "token": "storage",
+                "foreground": "#ffad66"
+            },
+            {
+                "token": "identifier",
+                "foreground": "#deff8a"
+            },
+            {
+                "token": "tag",
+                "foreground": "#ffb3d9"
+            },
+            {
+                "token": "attribute.value",
+                "foreground": "#f9fe95"
+            },
+            {
+                "token": "attribute.name",
+                "foreground": "#fdd686"
+            },
+            {
+                "token": "selector.class",
+                "foreground": "#d19a66"
+            }
+        ],
+        "colors": {
+            "editor.background": "#232935",
+            "editor.lineHighlightBackground": "#1a1d28"
+        }
+    }
+}

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -107,6 +107,87 @@
   --log-warn: rgb(178, 145, 0);
 }
 
+[data-theme='mosqueta-dark'] {
+  --app-background: #171a25;
+  --app-foreground: rgb(51, 51, 51);
+
+  --aside-sections-background: #171a25;
+  --aside-sections-border: transparent;
+
+  --aside-bar-background: #1e2530;
+  --aside-bar-foreground: rgb(204, 204, 204);
+  --aside-bar-border: transparent;
+
+  --grid-background: #171a25;
+
+  --button-foreground: rgba(255, 255, 255, 0.4);
+  --button-foreground-active: #ff89ef;
+  --button-border-active: #40142c;
+  --button-background-active: #40142c;
+
+  --button-title-background: #171a25;
+  --button-title-foreground: rgb(225, 228, 232);
+  --button-title-border: rgb(51, 51, 51);
+
+  --input-background: #171a25;
+  --input-foreground: #ff89ef;
+  --input-border: #171a25;
+}
+
+[data-theme='dracula'] {
+  --app-background: #171a25;
+  --app-foreground: rgb(51, 51, 51);
+
+  --aside-sections-background: #353646;
+  --aside-sections-border: transparent;
+
+  --aside-bar-background: #20232c;
+  --aside-bar-foreground: #ffffff;
+  --aside-bar-border: transparent;
+
+  --grid-background: #171a25;
+
+  --button-foreground: #6473a6;
+  --button-foreground-active: #ffffff;
+  --button-border-active: #40142c;
+  --button-background-active: #40142c;
+
+  --button-title-background: #171a25;
+  --button-title-foreground: rgb(225, 228, 232);
+  --button-title-border: rgb(51, 51, 51);
+
+  --input-background: #454659;
+  --input-foreground: #ffffff;
+  --input-border: #171a25;
+}
+
+[data-theme='one-dark-pro'] {
+  --app-background: #171a25;
+  --app-foreground: rgb(51, 51, 51);
+
+  --aside-sections-background: #282b34;
+  --aside-sections-border: transparent;
+
+  --aside-bar-background: #21262c;
+  --aside-bar-foreground: #ffffff;
+  --aside-bar-border: transparent;
+
+  --grid-background: #171a25;
+
+  --button-foreground: #6e7077;
+  --button-foreground-active: #ffffff;
+  --button-border-active: #40142c;
+  --button-background-active: #40142c;
+
+  --button-title-background: #171a25;
+  --button-title-foreground: rgb(225, 228, 232);
+  --button-title-border: rgb(51, 51, 51);
+
+  --input-background: #404554;
+  --input-foreground: #ffffff;
+  --input-border: #171a25;
+}
+
 body {
   background-color: var(--app-background);
   color: var(--app-foreground);


### PR DESCRIPTION
# New Themes

Add three new editor themes to enhance the user experience: **Dracula**, **One Dark Pro**, and **Mosqueta** (My custom theme). 
Includes automated theme registration via themes.json and updated base.css styles.

- themes.json is a new and easy way to add themes
- Updated base.css with new editor styles

### Notes: 
- Function name colors in the editor cannot be customized without using TypeScript.

## Dracula
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/c739390c-1e60-48c6-bafe-28280bee4392" />

## One Dark Pro
---
<img width="1919" height="873" alt="image" src="https://github.com/user-attachments/assets/c393d2c4-5f67-4d22-b9ce-c73cf9218f69" />

## Mosqueta
---
<img width="1919" height="871" alt="image" src="https://github.com/user-attachments/assets/6bcff54b-3fb9-4de8-8c01-d13675c703be" />
