### PR TITLE
feat(ui): add background colors and padding to headers for better visibility and layout consistency

### DIFF
--- a/src/css/console.css
+++ b/src/css/console.css
@@ -4,6 +4,8 @@
     top: 0;
     z-index: 1;
     padding-top: 1em;
+    background-color: var(--aside-bar-background);
+    padding-bottom: 8px;
   }
 
   & .console-type {
@@ -45,7 +47,7 @@
       background: rgb(235, 189, 189);
       border: 2px solid rgb(204, 0, 0);
       color: black;
-      padding-top: 0.5em
+      padding-top: 0.5em;
     }
 
     & .error::before {
@@ -55,51 +57,51 @@
     }
 
     & .log-log {
-      color: var(--log-log)
+      color: var(--log-log);
     }
 
     & .log-info {
-      color: var(--log-info)
+      color: var(--log-info);
     }
 
     & .log-error {
-      color: var(--log-error)
+      color: var(--log-error);
     }
 
     & .log-warn {
-      color: var(--log-warn)
+      color: var(--log-warn);
     }
 
     & .log-debug {
-      color: var(--log-debug, #ab47bc)
+      color: var(--log-debug, #ab47bc);
     }
 
     & .log-table {
-      color: var(--log-table, #66bb6a)
+      color: var(--log-table, #66bb6a);
     }
 
     & .log-count {
-      color: var(--log-count, #26c6da)
+      color: var(--log-count, #26c6da);
     }
 
     & .log-trace {
-      color: var(--log-trace, #8d6e63)
+      color: var(--log-trace, #8d6e63);
     }
 
     & .log-dir {
-      color: var(--log-dir, #78909c)
+      color: var(--log-dir, #78909c);
     }
 
     & .log-dirxml {
-      color: var(--log-dirxml, #78909c)
+      color: var(--log-dirxml, #78909c);
     }
 
     & .log-time {
-      color: var(--log-time, #ffd54f)
+      color: var(--log-time, #ffd54f);
     }
 
     & .log-assert {
-      color: var(--log-assert, #ff7043)
+      color: var(--log-assert, #ff7043);
     }
   }
 
@@ -137,17 +139,17 @@
   }
 
   .console-fn::before {
-    content: "ƒ ";
+    content: 'ƒ ';
     font-style: italic;
     color: #ce9178;
   }
 
   .console-async-fn::before {
-    content: "async ƒ ";
+    content: 'async ƒ ';
   }
 
   .console-generator-fn::before {
-    content: "ƒ* ";
+    content: 'ƒ* ';
   }
 
   .console-badge {

--- a/src/css/history.css
+++ b/src/css/history.css
@@ -5,6 +5,8 @@
     z-index: 1;
     padding-top: 1em;
     padding-left: 0.5em;
+    background-color: var(--aside-bar-background);
+    padding-bottom: 8px;
   }
 
   & .history-item {
@@ -37,7 +39,9 @@
       color: #fff;
       cursor: pointer;
       padding: 6px 8px 6px 6px;
-      transition: 0.2s ease background-color, 0.2s ease scale;
+      transition:
+        0.2s ease background-color,
+        0.2s ease scale;
       border-radius: 4px;
 
       &:hover {
@@ -129,7 +133,9 @@
         gap: 6px;
 
         & button {
-          transition: 0.2s ease opacity, 0.2s ease scale;
+          transition:
+            0.2s ease opacity,
+            0.2s ease scale;
           border: none;
           background: none;
           color: #fff;
@@ -149,10 +155,8 @@
             width: 18px;
             height: 18px;
           }
-
         }
       }
     }
-
   }
 }

--- a/src/css/skypack.css
+++ b/src/css/skypack.css
@@ -4,6 +4,7 @@
     top: 0;
     z-index: 1;
     padding-top: 1em;
+    background-color: var(--aside-bar-background);
   }
 
   & .skypack-type {


### PR DESCRIPTION
# PR Description
This PR fixes styling issues where headers in various sidebar panels appeared transparent or lacked proper spacing, affecting readability during scrolling.

## Key Changes:

- Added background colors to headers in the Dependencies, Console, and History sections to ensure they remain visible and distinct.
- Adjusted padding across these headers to improve layout consistency and alignment.
- Fixed the transparency issue reported when scrolling through search results and panel content.

---

## Screenshots / Evidence

### Dependencies Section Header
| Before | After |
| --- | --- |
| <img width="406" height="618" alt="image" src="https://github.com/user-attachments/assets/6c1afe90-b9bb-4768-b336-0f4b76efdf7d" /> | <img width="365" height="787" alt="Captura de pantalla 2026-01-30 a la(s) 12 37 20 p m" src="https://github.com/user-attachments/assets/6ff94ac9-bdeb-4a15-80d4-eb9fc780fb11" /> |

### Console Section Header
| Before | After |
| --- | --- |
| <img width="419" height="679" alt="Captura de pantalla 2026-01-30 a la(s) 1 05 42 p m" src="https://github.com/user-attachments/assets/8799a107-80f2-4b91-9b96-d6e879798f96" /> | <img width="363" height="591" alt="Captura de pantalla 2026-01-30 a la(s) 12 37 47 p m" src="https://github.com/user-attachments/assets/b8e7ee76-6aba-4a6a-9c2f-9ead3e3def89" /> |

### History Section Header

| Before | After |
| --- | --- |
| <img width="398" height="476" alt="image" src="https://github.com/user-attachments/assets/53c33765-3ff3-43c9-b061-7fbea2606e04" /> | <img width="387" height="544" alt="Captura de pantalla 2026-01-30 a la(s) 12 38 44 p m" src="https://github.com/user-attachments/assets/6c44932b-ca6b-401b-bfab-3740d9e8f981" /> |

---

Related Issue: #283 