### PR TITLE
fix: prevent HTML tag duplication in ZIP export

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -31,22 +31,84 @@ async function createZipWithSingleFile ({ htmlContent, cssContent, jsContent }) 
 async function createZipWithMultipleFiles ({ htmlContent, cssContent, jsContent }) {
   const zip = await getZip()
 
-  const indexHtml = `<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <link type="text/css" rel="stylesheet" href="style.css"/>
-  </head>
-  <body>
-    ${htmlContent}
-    <script type="module" src="script.js"></script>
-  </body>
-</html>`
+  const indexHtml = buildIndexHtml(htmlContent)
 
   return await zip([
     { name: 'style.css', input: cssContent },
     { name: 'script.js', input: jsContent },
     { name: 'index.html', input: indexHtml }
   ]).blob()
+}
+
+function buildIndexHtml (html) {
+  const hasDoctype = /<!doctype\s+html[^>]*>/i.test(html)
+  const hasHtml = /<html[\s>]/i.test(html)
+  const hasHead = /<head[\s>]/i.test(html)
+  const hasBody = /<body[\s>]/i.test(html)
+  const hasStyleLink = /<link[^>]*href=["']style\.css["'][^>]*>/i.test(html)
+  const hasScript = /<script[^>]*src=["']script\.js["'][^>]*>/i.test(html)
+
+  let result = html
+
+  // Add script before </body> or at the end
+  if (!hasScript) {
+    if (hasBody) {
+      result = result.replace(/<\/body>/i, '    <script type="module" src="script.js"></script>\n  </body>')
+    } else {
+      result = result + '\n    <script type="module" src="script.js"></script>'
+    }
+  }
+
+  // Add stylesheet link inside <head> or store for later
+  if (!hasStyleLink) {
+    if (hasHead) {
+      result = result.replace(/<head([^>]*)>/i, '<head$1>\n    <link type="text/css" rel="stylesheet" href="style.css"/>')
+    }
+    // If no <head>, it will be added below with the link included
+  }
+
+  // Add <head> if missing
+  if (!hasHead) {
+    const headBlock = '  <head>\n    <link type="text/css" rel="stylesheet" href="style.css"/>\n  </head>'
+    if (hasBody) {
+      result = result.replace(/<body/i, headBlock + '\n  <body')
+    } else if (hasHtml) {
+      result = result.replace(/<html([^>]*)>/i, '<html$1>\n' + headBlock)
+    } else {
+      result = headBlock + '\n' + result
+    }
+  }
+
+  // Wrap in <body> if missing
+  if (!hasBody) {
+    if (hasHtml) {
+      // Find content after </head> and before </html>, wrap it in <body>
+      result = result.replace(/(<\/head>)([\s\S]*?)(<\/html>)/i, '$1\n  <body>\n    $2\n  </body>\n$3')
+    } else {
+      // Find content after </head> and wrap the rest in <body>
+      const headEnd = result.indexOf('</head>')
+      if (headEnd !== -1) {
+        const afterHead = headEnd + '</head>'.length
+        const before = result.slice(0, afterHead)
+        const after = result.slice(afterHead)
+        result = before + '\n  <body>' + after + '\n  </body>'
+      } else {
+        result = '  <body>\n' + result + '\n  </body>'
+      }
+    }
+  }
+
+  // Wrap in <html> if missing
+  if (!hasHtml) {
+    result = '<html lang="en">\n' + result + '\n</html>'
+  }
+
+  // Add DOCTYPE if missing
+  if (!hasDoctype) {
+    result = '<!DOCTYPE html>\n' + result
+  }
+
+  return result
 }
 
 function generateZip ({ zipBlob, zipFileName }) {


### PR DESCRIPTION
Currently, when exporting code as a ZIP file, the `index.html` is generated by wrapping the user's input within a static template. This causes structural issues and tag duplication (e.g., double `<html>` or `<body>` tags) if the user provides a complete HTML boilerplate.

This PR introduces a **smart wrapping logic** that detects existing structural elements and only injects the missing parts, ensuring a valid and clean HTML document.

## Changes
- **Refactored `src/download.js`**: Replaced the hardcoded template literal in `createZipWithMultipleFiles` with a dedicated `buildIndexHtml` helper function.
- **Implemented `buildIndexHtml`**: Added logic to conditionally inject the following elements only if they are missing:
  - `<!DOCTYPE html>`
  - `<html lang="en">`
  - `<head>` (including the `<link>` to `style.css`)
  - `<body>`
  - `<script type="module" src="script.js">`

## Benefits
- **Zero Redundancy**: Users can provide either a full HTML document or a simple fragment; the output remains valid and non-redundant.
- **Robust Detection**: The implementation uses case-insensitive Regex to account for attributes (e.g., `<body class="dark">` or `<html lang="es">`).
- **Improved DX**: Prevents broken layouts in downloaded projects.

## Testing Performed
- [x] **Fragment Test**: Verified that simple HTML (e.g., `<h1>Hello</h1>`) is correctly wrapped in a full template.
- [x] **Boilerplate Test**: Verified that full HTML documents are exported without duplicate injections.
- [x] **Linting**: Validated code style compliance with `neostandard`.